### PR TITLE
free the PG(auto_prepend_file) only when tideways.auto_prepend_library is set

### DIFF
--- a/tideways.c
+++ b/tideways.c
@@ -1571,9 +1571,9 @@ PHP_RSHUTDOWN_FUNCTION(tideways)
 
 	if (hp_globals.prepend_overwritten == 1) {
 		efree(PG(auto_prepend_file));
+		PG(auto_prepend_file) = NULL;
+		hp_globals.prepend_overwritten = 0;
 	}
-	PG(auto_prepend_file) = NULL;
-	hp_globals.prepend_overwritten = 0;
 
 	return SUCCESS;
 }


### PR DESCRIPTION
when user has it's own auto_prepend_file and sets tideways.auto_prepend_library to 0
the PG(auto_prepend_file) will be freed and set to NULL at request shutdown, it will break the user's configuration