### PR TITLE
Add missing zend_exceptions.h include to get zend_exception_get_default definition

### DIFF
--- a/tideways.c
+++ b/tideways.c
@@ -37,6 +37,7 @@
 #include "php_tideways.h"
 #include "spans.h"
 #include "zend_extensions.h"
+#include "zend_exceptions.h"
 #include "zend_gc.h"
 
 #include "ext/standard/url.h"


### PR DESCRIPTION
To prevent this:

Function `zend_exception_get_default' implicitly converted to pointer at /«PKGBUILDDIR»/tideways.c:2301
Function `zend_exception_get_default' implicitly converted to pointer at /«PKGBUILDDIR»/tideways.c:2301



Our automated build log filter detected the problem(s) above that will
likely cause your package to segfault on architectures where the size of
a pointer is greater than the size of an integer, such as ia64 and amd64.

This is often due to a missing function prototype definition.

Since use of implicitly converted pointers is always fatal to the application
on ia64, they are errors.  Please correct them for your next upload.

More information can be found at:
http://wiki.debian.org/ImplicitPointerConversions