### PR TITLE
Update expected test output for array with two elements

### DIFF
--- a/tests/tideways_spans_012.phpt
+++ b/tests/tideways_spans_012.phpt
@@ -16,7 +16,7 @@ tideways_disable();
 
 var_dump(tideways_get_spans());
 --EXPECTF--
-array(1) {
+array(2) {
   [0]=>
   array(4) {
     ["n"]=>


### PR DESCRIPTION
Automated build is currently failing on this test. This fixes it.