### PR TITLE
Add support for Flow framework version 4

### DIFF
--- a/tests/tideways_023.phpt
+++ b/tests/tideways_023.phpt
@@ -112,13 +112,25 @@ function transaction_laravel() {
 
 function transaction_flow3() {
     tideways_enable(TIDEWAYS_FLAGS_NO_SPANS, array(
-        'transaction_function' => 'TYPO3\Flow\Mvc\Controller\ActionController::callActionMethod',
+        'transaction_function' => 'TYPO3\Flow\Mvc\Controller\ActionController_Original::callActionMethod',
     ));
 
     $ctrl = new \TYPO3\Flow\Mvc\Controller\FooController();
     $ctrl->processRequest();
 
     echo "FLOW3: " . tideways_transaction_name() . "\n";
+    $data = tideways_disable();
+}
+
+function transaction_flow4() {
+    tideways_enable(TIDEWAYS_FLAGS_NO_SPANS, array(
+        'transaction_function' => 'Neos\Flow\Mvc\Controller\ActionController_Original::callActionMethod',
+    ));
+
+    $ctrl = new \Neos\Flow\Mvc\Controller\FooController();
+    $ctrl->processRequest();
+
+    echo "FLOW4: " . tideways_transaction_name() . "\n";
     $data = tideways_disable();
 }
 
@@ -130,6 +142,7 @@ transaction_wordpress();
 transaction_zf1();
 transaction_laravel();
 transaction_flow3();
+transaction_flow4();
 
 --EXPECTF--
 Symfony2: foo::bar
@@ -140,3 +153,4 @@ Wordpress: home
 Zend Framework 1: MyController::fooAction
 Laravel: CachetHQ\Cachet\Http\Controllers\RssController::indexAction
 FLOW3: TYPO3\Flow\Mvc\Controller\FooController::indexAction
+FLOW4: Neos\Flow\Mvc\Controller\FooController::indexAction

--- a/tests/tideways_023_classes.php
+++ b/tests/tideways_023_classes.php
@@ -32,7 +32,7 @@ namespace CachetHQ\Cachet\Http\Controllers {
 }
 
 namespace TYPO3\Flow\Mvc\Controller {
-    abstract class ActionController {
+    abstract class ActionController_Original {
         protected $actionMethodName = 'indexAction';
 
         public function processRequest()
@@ -42,5 +42,22 @@ namespace TYPO3\Flow\Mvc\Controller {
 
         protected function callActionMethod() {}
     }
+    class ActionController extends ActionController_Original {}
+    class FooController extends ActionController {}
+}
+
+
+namespace Neos\Flow\Mvc\Controller {
+    abstract class ActionController_Original {
+        protected $actionMethodName = 'indexAction';
+
+        public function processRequest()
+        {
+            $this->callActionMethod();
+        }
+
+        protected function callActionMethod() {}
+    }
+    class ActionController extends ActionController_Original {}
     class FooController extends ActionController {}
 }

--- a/tideways.c
+++ b/tideways.c
@@ -2553,7 +2553,6 @@ void hp_init_trace_callbacks(TSRMLS_D)
     register_trace_callback("Mage_Core_Block_Abstract::toHtml", cb);
     register_trace_callback("Magento\\Framework\\View\\Element\\AbstractBlock::toHtml", cb);
     register_trace_callback("Neos\\Flow\\Mvc\\View\\JsonView::render", cb);
-    register_trace_callback("Neos\\FluidAdaptor\\View\\AbstractTemplateView::render", cb);
     register_trace_callback("TYPO3\\Flow\\Mvc\\View\\JsonView::render", cb);
     register_trace_callback("TYPO3\\Fluid\\View\\AbstractTemplateView::render", cb);
     register_trace_callback("TYPO3\\CMS\\Extbase\\Mvc\\View\\JsonView::render", cb);

--- a/tideways.c
+++ b/tideways.c
@@ -3073,9 +3073,9 @@ static void hp_detect_transaction_name(char *ret, zend_execute_data *data TSRMLS
             TWG(transaction_name) = zend_string_init(ctrl, len-1, 0);
             efree(ctrl);
         }
-    } else if(strcmp(ret, "Neos\\Flow\\Mvc\\Controller\\ActionController::callActionMethod") == 0 ||
+    } else if(strcmp(ret, "Neos\\Flow\\Mvc\\Controller\\ActionController_Original::callActionMethod") == 0 ||
               strcmp(ret, "TYPO3\\CMS\\Extbase\\Mvc\\Controller\\ActionController::callActionMethod") == 0 ||
-              strcmp(ret, "TYPO3\\Flow\\Mvc\\Controller\\ActionController::callActionMethod") == 0) {
+              strcmp(ret, "TYPO3\\Flow\\Mvc\\Controller\\ActionController_Original::callActionMethod") == 0) {
 
         zval *property;
         zval *object = EX_OBJ(data);

--- a/tideways.c
+++ b/tideways.c
@@ -2532,6 +2532,7 @@ void hp_init_trace_callbacks(TSRMLS_D)
 
     cb = tw_trace_callback_event_dispatchers2;
     register_trace_callback("HookCore::coreCallHook", cb); // PrestaShop 1.6
+    register_trace_callback("Neos\\Flow\\SignalSlot\\Dispatcher::dispatch", cb);
     register_trace_callback("TYPO3\\Flow\\SignalSlot\\Dispatcher::dispatch", cb);
     register_trace_callback("TYPO3\\CMS\\Extbase\\SignalSlot\\Dispatcher::dispatch", cb);
 
@@ -2551,6 +2552,8 @@ void hp_init_trace_callbacks(TSRMLS_D)
     cb = tw_trace_callback_view_class;
     register_trace_callback("Mage_Core_Block_Abstract::toHtml", cb);
     register_trace_callback("Magento\\Framework\\View\\Element\\AbstractBlock::toHtml", cb);
+    register_trace_callback("Neos\\Flow\\Mvc\\View\\JsonView::render", cb);
+    register_trace_callback("Neos\\FluidAdaptor\\View\\AbstractTemplateView::render", cb);
     register_trace_callback("TYPO3\\Flow\\Mvc\\View\\JsonView::render", cb);
     register_trace_callback("TYPO3\\Fluid\\View\\AbstractTemplateView::render", cb);
     register_trace_callback("TYPO3\\CMS\\Extbase\\Mvc\\View\\JsonView::render", cb);
@@ -3071,7 +3074,8 @@ static void hp_detect_transaction_name(char *ret, zend_execute_data *data TSRMLS
             TWG(transaction_name) = zend_string_init(ctrl, len-1, 0);
             efree(ctrl);
         }
-    } else if(strcmp(ret, "TYPO3\\CMS\\Extbase\\Mvc\\Controller\\ActionController::callActionMethod") == 0 ||
+    } else if(strcmp(ret, "Neos\\Flow\\Mvc\\Controller\\ActionController::callActionMethod") == 0 ||
+              strcmp(ret, "TYPO3\\CMS\\Extbase\\Mvc\\Controller\\ActionController::callActionMethod") == 0 ||
               strcmp(ret, "TYPO3\\Flow\\Mvc\\Controller\\ActionController::callActionMethod") == 0) {
 
         zval *property;


### PR DESCRIPTION
The vendor name was changed with Flow 4, so this needs to be supported.

Also, the method used for detection is defined in a "clone" of the source class
that has `_Original` appended to it's name. Since a straight match is done, the
comparison needs to be done against the name of that "clone".