### PR TITLE
Issue #111: Fix timebase calculation

### DIFF
--- a/tideways_xhprof.c
+++ b/tideways_xhprof.c
@@ -144,8 +144,8 @@ PHP_MSHUTDOWN_FUNCTION(tideways_xhprof)
 
 PHP_RINIT_FUNCTION(tideways_xhprof)
 {
-    tracing_request_init(TSRMLS_C);
     TXRG(clock_source) = determine_clock_source(TXRG(clock_use_rdtsc));
+    tracing_request_init(TSRMLS_C);
 
     CG(compiler_options) = CG(compiler_options) | ZEND_COMPILE_NO_BUILTINS;
 


### PR DESCRIPTION
tracing_request_init is using the clock_source - so timebase will always be 1 if auto-clock source is different from selected clock source.

Closes: #111